### PR TITLE
hide the honeypot field, and fix $muted reference as $form-muted

### DIFF
--- a/_form-gravity.scss
+++ b/_form-gravity.scss
@@ -24,7 +24,7 @@
 .gsection {
 	@include form-spacing( margin-bottom, $form-space );
 	@include form-spacing( padding-bottom, $form-space );
-	border-bottom: 1px solid $muted;
+	border-bottom: 1px solid $form-muted;
 
 	.gsection_title { @include form-spacing( margin-bottom, $form-space ); }
 }
@@ -299,6 +299,13 @@ input.datepicker_with_icon {
 	  &:focus { border-color: darken($input-error, 10% ); }
 	}
 
+}
+
+/* honeypot field, hide it from human beings */
+.gform_validation_container {
+	display: none;
+	position: absolute;
+	left: -9000px;
 }
 
 .ui-datepicker {


### PR DESCRIPTION
If you enable the anti-spam honeypot in a form's settings, it needs to be hidden. I've just picked up Gravity Forms' rules and used them here, but of course without the excessive selectors or `!important` since the target is a sane custom theme :)

I also noticed that there's a reference to `$muted` which I assumed was meant to be `$form-muted`, so I've changed that too. I didn't do anything with `$white` or `$gray` as I assume we're meant to define those in our own stylesheets.
