### PR TITLE
Fix code standards

### DIFF
--- a/_form-default.scss
+++ b/_form-default.scss
@@ -1,7 +1,8 @@
-label{
+label {
 	color: $input-label;
 	font-weight: 700;
 }
+
 input[type="text"],
 input[type="search"],
 input[type="password"],
@@ -12,7 +13,7 @@ input[type="tel"],
 input[type="file"],
 textarea,
 select {
-	@include form-spacing( padding, $form-space );
+	@include form-spacing(padding, $form-space);
 	background: $input-bg;
 	color: $input-color;
 	border: 1px solid $input-border;
@@ -22,25 +23,25 @@ select {
 	box-shadow: $input-shadow;
 	transition: $input-transition;
 
-	&:focus{
+	&:focus {
 		border-color: $input-border-focus;
 		outline: none;
 	}
 }
 
 input[type="file"] {
-
 	&:hover { cursor: pointer; }
 }
 
-input[type="search"]{
+input[type="search"] {
 	width: auto;
 	display: inline-block;
 }
 
 select {
-	height: ceil( $form-line-height * 1.33 );
+	height: ceil($form-line-height * 1.33);
 }
+
 select[multiple],
 select[size] {
 	height: auto;
@@ -52,39 +53,34 @@ input[type="radio"] {
 	display: inline-block;
 }
 
-
 input[type="submit"],
 input[type="reset"],
 input[type="button"],
 button {
-	@include form-spacing( padding, $form-space $form-space * 2 );
-	@include form-font-size( 14px );
+	@include form-spacing(padding, $form-space $form-space * 2);
+	@include form-font-size(14px);
 	background: $form-button-background;
 	color: $form-button-color;
 	display: inline-block;
 	font-weight: 400;
 	text-transform: uppercase;
-	border: none;
+	border: 0;
 	transition: $input-transition;
 
-	&:hover{
+	&:hover {
 		background: $form-button-background-hover;
 	}
 }
 
-/**
- * WebKit-style focus
- *
- * @link https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/mixins/_tab-focus.scss [props]
- */
+// WebKit-style focus
+// @link https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/mixins/_tab-focus.scss [props]
 input[type="checkbox"],
 input[type="radio"],
 input[type="submit"],
 input[type="reset"],
 input[type="button"],
 button {
-
-	&:focus{
+	&:focus {
 		outline: thin dotted;
 		outline: 5px auto -webkit-focus-ring-color;
 		outline-offset: -2px;

--- a/_form-gravity.scss
+++ b/_form-gravity.scss
@@ -7,26 +7,32 @@
 .gf_list_5col,
 .gf_list_inline,
 .gf_page_steps,
-.ui-datepicker-header { @include form-clearfix; }
+.ui-datepicker-header {
+	@include form-clearfix;
+}
 
 .gform_wrapper form {
-    @include form-spacing(  margin-bottom, $form-space  );
+	@include form-spacing(margin-bottom, $form-space);
 }
 
 .gform_heading {
-	@include form-spacing(  margin-bottom, $form-space * 2  );
-	@include form-spacing(  padding-bottom, $form-space  );
-	border-bottom: 1px solid lighten( $form-muted,25%  );
+	@include form-spacing(margin-bottom, $form-space * 2);
+	@include form-spacing(padding-bottom, $form-space);
+	border-bottom: 1px solid lighten($form-muted, 25%);
 
-	.gform_title { @include form-spacing( margin-bottom, $form-space ); }
+	.gform_title {
+		@include form-spacing(margin-bottom, $form-space);
+	}
 }
 
 .gsection {
-	@include form-spacing( margin-bottom, $form-space );
-	@include form-spacing( padding-bottom, $form-space );
+	@include form-spacing(margin-bottom, $form-space);
+	@include form-spacing(padding-bottom, $form-space);
 	border-bottom: 1px solid $form-muted;
 
-	.gsection_title { @include form-spacing( margin-bottom, $form-space ); }
+	.gsection_title {
+		@include form-spacing(margin-bottom, $form-space);
+	}
 }
 
 .gfield_required {
@@ -34,28 +40,36 @@
 	padding-left: 2px;
 }
 
-.ginput_complex label { font-weight: normal; }
+.ginput_complex label {
+	font-weight: normal;
+}
 
 .gform_fields {
 	margin: 0;
 	list-style: none;
 }
 
-.gfield { @include form-spacing( margin-bottom, $form-space ); }
+.gfield {
+	@include form-spacing(margin-bottom, $form-space);
+}
 
 .gfield_description {
-	@include form-font-size( 14px );
+	@include form-font-size(14px);
 	font-style: italic;
 }
 
-.validation_message { font-style:normal; }
+.validation_message {
+	font-style: normal;
+}
 
 .gfield_checkbox,
 .gfield_radio {
 	list-style: none;
 	margin: 0;
 
-	input { @include form-spacing( margin-right, 4px ); }
+	input {
+		@include form-spacing(margin-right, 4px);
+	}
 }
 
 .gfield_radio {
@@ -81,28 +95,29 @@
 
 .name_prefix {
 	width: 10%;
-	float:left;
-	margin-right:1%;
+	float: left;
+	margin-right: 1%;
 }
+
 .name_first {
 	width: 39%;
-	float:left;
-	margin-right:1%;
+	float: left;
+	margin-right: 1%;
 }
 
 .name_last {
 	width: 39%;
-	float:left;
-	margin-right:1%;
+	float: left;
+	margin-right: 1%;
 }
 
 .name_suffix {
 	width: 9%;
-	float:right;
+	float: right;
 }
 
 input.datepicker_with_icon {
-	@include form-spacing( margin-right, $form-space );
+	@include form-spacing(margin-right, $form-space);
 	display: inline-block;
 	width: auto;
 }
@@ -110,48 +125,51 @@ input.datepicker_with_icon {
 .gfield_date_month,
 .gfield_date_dropdown_month {
 	display: inline-block;
-	width:auto;
-	margin-right:1%;
+	width: auto;
+	margin-right: 1%;
 }
 
 .gfield_date_day,
 .gfield_date_dropdown_day {
 	display: inline-block;
-	width:auto;
-	margin-right:1%;
+	width: auto;
+	margin-right: 1%;
 }
 
 .gfield_date_year,
 .gfield_date_dropdown_year {
 	display: inline-block;
-	width:auto;
+	width: auto;
 }
 
 .gfield_time_hour {
-	float:left;
-	margin-right:1%;
+	float: left;
+	margin-right: 1%;
 
 	input {
 		width: inherit;
 		display: inline-block;
 	}
+
 	label { display: block; }
 }
 
 .gfield_time_minute {
 	width: 30%;
-	float:left;
-	margin-right:1%;
+	float: left;
+	margin-right: 1%;
 }
 
 .gfield_time_ampm {
 	width: 20%;
-	float:left;
-	margin-right:1%;
+	float: left;
+	margin-right: 1%;
 }
 
 .gfield,
-.gform_footer { clear: both; }
+.gform_footer {
+	clear: both;
+}
 
 .gf_left_half {
 	width: 49%;
@@ -191,7 +209,6 @@ input.datepicker_with_icon {
 	vertical-align: top;
 }
 
-
 .gf_list_2col li {
 	width: 50%;
 	float: left;
@@ -217,33 +234,47 @@ input.datepicker_with_icon {
 	margin-right: 1%;
 }
 
-.gf_list_height_25 li { height: 25px; }
+.gf_list_height_25 li {
+	height: 25px;
+}
 
-.gf_list_height_50 li { height: 50px; }
+.gf_list_height_50 li {
+	height: 50px;
+}
 
-.gf_list_height_75 li { height: 75px; }
+.gf_list_height_75 li {
+	height: 75px;
+}
 
-.gf_list_height_100 li { height: 100px; }
+.gf_list_height_100 li {
+	height: 100px;
+}
 
-.gf_list_height_125 li { height: 125px; }
+.gf_list_height_125 li {
+	height: 125px;
+}
 
-.gf_list_height_150 li { height: 150px; }
-
+.gf_list_height_150 li {
+	height: 150px;
+}
 
 .gfield_list {
 	margin: 0;
 
 }
+
 .gfield_list > tbody > tr:nth-child(odd) > td,
 .gfield_list > tbody > tr:nth-child(odd) > th {
-	@include form-spacing( padding-right, $form-space );
+	@include form-spacing(padding-right, $form-space);
 	background: none;
 	line-height: normal;
 	padding: 0;
-	border: none;
+	border: 0;
 }
 
-.gfield_list > thead > tr > th { border:none; }
+.gfield_list > thead > tr > th {
+	border: 0;
+}
 
 .gf_scroll_text {
 	padding: 12px;
@@ -251,31 +282,41 @@ input.datepicker_with_icon {
 	height: 180px;
 	overflow: auto;
 
-	p:last-of-type { margin-bottom: 0; }
+	p:last-of-type {
+		margin-bottom: 0;
+	}
 }
 
 .gf_hide_ampm {
-	.gfield_time_ampm { display: none; }
+	.gfield_time_ampm {
+		display: none;
+	}
 }
 
 .gf_hide_charleft {
-	.charleft { display: none; }
+	.charleft {
+		display: none;
+	}
 }
 
 .gf_page_steps {
-	@include form-spacing( margin-bottom, $form-space );
+	@include form-spacing(margin-bottom, $form-space);
 	line-height: 1;
 }
 
 .gf_step {
 	display: inline-block;
-	opacity: 0.2;
+	opacity: .2;
 	margin-right: 1%;
 
-	&:last-of-type { margin-right: 0; }
+	&:last-of-type {
+		margin-right: 0;
+	}
 }
 
-.gf_step_active { opacity: 1; }
+.gf_step_active {
+	opacity: 1;
+}
 
 .gf_step_number {
 	font-weight: bold;
@@ -284,24 +325,27 @@ input.datepicker_with_icon {
 
 .gfield_error {
 	padding: $form-space;
-	border: 1px solid #EEE;
+	border: 1px solid #eee;
 	border-left-width: 5px;
-	border-left-color: #D9534F;
+	border-left-color: #d9534f;
 
 	> label,
-	.validation_message { color: $input-error; }
+	.validation_message {
+		color: $input-error;
+	}
 
 	input,
 	textarea,
 	select {
-	  border-color: $input-error;
+		border-color: $input-error;
 
-	  &:focus { border-color: darken($input-error, 10% ); }
+		&:focus {
+			border-color: darken($input-error, 10%);
+		}
 	}
-
 }
 
-/* honeypot field, hide it from human beings */
+// honeypot field, hide it from human beings
 .gform_validation_container {
 	display: none;
 	position: absolute;
@@ -309,22 +353,23 @@ input.datepicker_with_icon {
 }
 
 .ui-datepicker {
-	background:$white;
-	border:1px solid $gray;
+	background: $white;
+	border: 1px solid $gray;
 }
 
 .ui-datepicker-prev {
-	width:20%;
-	float:left;
+	width: 20%;
+	float: left;
 }
 
 .ui-datepicker-next {
 	width: 20%;
-	float:right;
+	float: right;
 }
+
 .ui-datepicker-title {
 	width: 60%;
-	float:left;
+	float: left;
 
 	select {
 		width: auto;

--- a/_form-mixins.scss
+++ b/_form-mixins.scss
@@ -1,70 +1,51 @@
-/**
- * Form mixins
- * Handles the calculations and abstracted fun
- */
+// Form mixins - Handles the calculations and abstracted fun
 
-
-/**
- * Font sizing mixin
- *
- * @link https://github.com/csswizardry/inuit.css/blob/master/generic/_mixins.scss [props]
- *
- * @example
- * @include form-font-size(10px);
- */
-
-@mixin form-font-size( $font-size ) {
+// Font sizing mixin
+// @link https://github.com/csswizardry/inuit.css/blob/master/generic/_mixins.scss [props]
+// @example
+//@include form-font-size(10px);
+@mixin form-font-size($font-size) {
 	font-size: $font-size;
-	font-size: ( $font-size / $form-font-size ) * 1rem;
+	font-size: ($font-size / $form-font-size) * 1rem;
 }
 
-/**
- * Micro clearfix mixin
- *
- * @link http://www.css-101.org/articles/clearfix/latest-new-clearfix-so-far.php [props]
- *
- * @example
- * @include form-clearfix;
- */
-
+// Micro clearfix mixin
+// @link http://www.css-101.org/articles/clearfix/latest-new-clearfix-so-far.php [props]
+// @example
+// @include form-clearfix;
 @mixin form-clearfix {
-	&:after {
-		content: "";
-		display: table;
+	&::after {
 		clear: both;
+		content: '';
+		display: table;
 	}
 }
 
-/**
- * Spacing mixin
- *
- * @link https://twitter.com/HugoGiraudel [props]
- *
- * @example
- * @include form-spacing(padding, 0 $form-space auto);
- */
-
+// Spacing mixin
+// @link https://twitter.com/HugoGiraudel [props]
+// @example
+// @include form-spacing(padding, 0 $form-space auto);
 @mixin form-spacing($spacing-type, $args) {
-    $fallback: ();
-    $regular: ();
+	$fallback: ();
+	$regular: ();
 
-    @each $value in $args {
-      @if type-of($value) == "number" and unit($value) == "px" {
-        $fallback: append($fallback, $value);
-        $regular: append($regular, $value / $form-font-size * 1rem);
-      }
+	@each $value in $args {
+		@if type-of($value) == 'number' and unit($value) == 'px' {
+			$fallback: append($fallback, $value);
+			$regular: append($regular, $value / $form-font-size * 1rem);
+		}
 
-      @else if type-of($value) == "number" and unit($value) == "rem" {
-        $fallback: append($fallback, $value / 1rem * $form-font-size);
-        $regular: append($regular, $value);
-      }
+		@else if type-of($value) == 'number' and unit($value) == 'rem' {
+			$fallback: append($fallback, $value / 1rem * $form-font-size);
+			$regular: append($regular, $value);
+		}
 
-      @else {
-        $fallback: append($fallback, $value);
-        $regular: append($regular, $value);
-      }
-    }
+		@else {
+			$fallback: append($fallback, $value);
+			$regular: append($regular, $value);
+		}
+	}
 
-    #{$spacing-type}: $fallback;
-    #{$spacing-type}: $regular;
+	#{$spacing-type}: $fallback;
+	#{$spacing-type}: $regular;
 }

--- a/_form-variables.scss
+++ b/_form-variables.scss
@@ -17,3 +17,6 @@ $form-muted:    #858585 !default;
 $form-font-size:   16px !default;
 $form-line-height: $form-font-size * 1.5 !default;
 $form-space:       $form-line-height / 2 !default;
+
+$white: #fff !default;
+$gray:  #aaa !default;

--- a/_form-variables.scss
+++ b/_form-variables.scss
@@ -1,19 +1,19 @@
-$input-bg:				#fff !default;
-$input-color:				#999 !default;
-$input-border:			#ddd !default;
-$input-border-focus:			#999 !default;
-$input-label:				#666 !default;
-$input-error:				#CA3C3C !default;
-$input-shadow:			1px 1px 2px #EEE inset !default;
-$input-transition:			all 0.3s ease-in-out !default;
+$input-bg:           #fff !default;
+$input-color:        #999 !default;
+$input-border:       #ddd !default;
+$input-border-focus: #999 !default;
+$input-label:        #666 !default;
+$input-error:        #ca3c3c !default;
+$input-shadow:       1px 1px 2px #eee inset !default;
+$input-transition:   all .3s ease-in-out !default;
 
-$form-button-background:		#333 !default;
-$form-button-background-hover:	#0078E7 !default;
-$form-button-color:			#fff !default;
+$form-button-background:       #333 !default;
+$form-button-background-hover: #0078e7 !default;
+$form-button-color:            #fff !default;
 
-$form-required:			#F00 !default;
-$form-muted:				#858585 !default;
+$form-required: #f00 !default;
+$form-muted:    #858585 !default;
 
-$form-font-size:			16px !default;
-$form-line-height:			$form-font-size * 1.5 !default;
-$form-space:				$form-line-height / 2 !default;
+$form-font-size:   16px !default;
+$form-line-height: $form-font-size * 1.5 !default;
+$form-space:       $form-line-height / 2 !default;


### PR DESCRIPTION
I realise some of these may seem personal, but the suggested changes bring the SCSS code standards more into line with the CSS code standards.

Here's the `.scss-lint.yml` file I'm using: https://github.com/GaryJones/incipio/blob/develop/.scss-lint.yml - this isn't supported officially by WP, but I think it matches the WP CS for CSS as close as possible, and I wouldn't expect any official standard to deviate too far from this in the long-term.

I'll leave comments within the PR for any other comments.
